### PR TITLE
Switch default port to 9090

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo ./setup.sh update       # update
 sudo ./setup.sh uninstall    # remove
 ```
 
-The service will be available on [http://{serverip}:5000](http://{serverip}:5000).
+The service will be available on [http://{serverip}:9090](http://{serverip}:9090).
 
 ## Admin User Setup (!Important!)
 

--- a/client/README.md
+++ b/client/README.md
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 Edit `config.toml`:
 
 ```toml
-server_url = "http://127.0.0.1:5000"  # URL of your MyLora server
+server_url = "http://127.0.0.1:9090"  # URL of your MyLora server
 data_dir = "./lora_mount"              # Directory for placeholders and downloads
 username = ""                          # Optional: user name for /login
 password = ""                          # Optional: password for /login

--- a/client/client.py
+++ b/client/client.py
@@ -99,7 +99,7 @@ class LazyDownloader:
 def load_config() -> tuple[str, Path, str, str]:
     with CONFIG_PATH.open("rb") as fh:
         cfg = tomllib.load(fh)
-    server_url = cfg.get("server_url", "http://127.0.0.1:5000")
+    server_url = cfg.get("server_url", "http://127.0.0.1:9090")
     data_dir = Path(cfg.get("data_dir", "./lora_mount"))
     username = cfg.get("username", "")
     password = cfg.get("password", "")

--- a/client/config.toml
+++ b/client/config.toml
@@ -1,4 +1,4 @@
-server_url = "http://127.0.0.1:5000"
+server_url = "http://127.0.0.1:9090"
 data_dir = "./lora_mount"
 # Optional login credentials. Leave empty for guest access.
 username = ""

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -32,7 +32,7 @@ Search LoRA metadata using an SQLite full text query.
 **Example call**
 
 ```bash
-curl "http://{serverip}:5000/search?query=lora"
+curl "http://{serverip}:9090/search?query=lora"
 ```
 
 **Example response**
@@ -63,7 +63,7 @@ Return search results including category information and a random preview image.
 **Example call**
 
 ```bash
-curl "http://{serverip}:5000/grid_data?q=cat&limit=20"
+curl "http://{serverip}:9090/grid_data?q=cat&limit=20"
 ```
 
 **Example response**
@@ -90,7 +90,7 @@ is added with the ID `0`.
 **Example call**
 
 ```bash
-curl "http://{serverip}:5000/categories"
+curl "http://{serverip}:9090/categories"
 ```
 
 **Example response**
@@ -113,7 +113,7 @@ Create a new category by posting its name as form data.
 **Example call**
 
 ```bash
-curl -X POST -F "name=Landscapes" http://{serverip}:5000/categories
+curl -X POST -F "name=Landscapes" http://{serverip}:9090/categories
 ```
 
 **Example response**
@@ -135,7 +135,7 @@ Assign an existing LoRA file to a category.
 
 ```bash
 curl -X POST -F "filename=awesome_lora.safetensors" -F "category_id=1" \
-  http://{serverip}:5000/assign_category
+  http://{serverip}:9090/assign_category
 ```
 
 **Example response**
@@ -158,7 +158,7 @@ Assign multiple LoRA files to a category.
 
 ```bash
 curl -X POST -F "files=a.safetensors" -F "files=b.safetensors" \
-  -F "category_id=1" http://{serverip}:5000/assign_categories
+  -F "category_id=1" http://{serverip}:9090/assign_categories
 ```
 
 **Example response**
@@ -180,7 +180,7 @@ Remove a LoRA file from the given category.
 
 ```bash
 curl -X POST -F "filename=awesome_lora.safetensors" -F "category_id=1" \
-  http://{serverip}:5000/unassign_category
+  http://{serverip}:9090/unassign_category
 ```
 
 **Example response**
@@ -199,7 +199,7 @@ exists the request fails with HTTP status `409`.
 
 ```bash
 curl -X POST -F "files=@awesome_lora.safetensors" \
-  http://{serverip}:5000/upload
+  http://{serverip}:9090/upload
 ```
 
 **Example response**
@@ -224,7 +224,7 @@ also upload a ZIP archive containing previews.
 **Example call**
 
 ```bash
-curl -X POST -F "files=@previews.zip" http://{serverip}:5000/upload_previews
+curl -X POST -F "files=@previews.zip" http://{serverip}:9090/upload_previews
 ```
 
 **Example response**
@@ -244,7 +244,7 @@ Delete a category by its ID.
 **Example call**
 
 ```bash
-curl -X POST -F "category_id=3" http://{serverip}:5000/delete_category
+curl -X POST -F "category_id=3" http://{serverip}:9090/delete_category
 ```
 
 **Example response**
@@ -261,7 +261,7 @@ Delete LoRA or preview files. Provide one or more `files` values as form data.
 
 ```bash
 curl -X POST -F "files=awesome_lora.safetensors" \
-  http://{serverip}:5000/delete
+  http://{serverip}:9090/delete
 ```
 
 **Example response**
@@ -272,4 +272,4 @@ curl -X POST -F "files=awesome_lora.safetensors" \
 
 ---
 
-All endpoints run on port `5000` and return JSON unless noted otherwise.
+All endpoints run on port `9090` and return JSON unless noted otherwise.

--- a/docs/upload_guide.md
+++ b/docs/upload_guide.md
@@ -1,10 +1,10 @@
 # Uploading LoRA Files
 
-This guide explains the different ways to upload `.safetensors` models and their preview images to a running MyLora instance. All examples assume the server is available at `http://{serverip}:5000`.
+This guide explains the different ways to upload `.safetensors` models and their preview images to a running MyLora instance. All examples assume the server is available at `http://{serverip}:9090`.
 
 ## 1. Using the Upload Wizard
 
-1. Open your browser and navigate to `http://{serverip}:5000/upload_wizard`.
+1. Open your browser and navigate to `http://{serverip}:9090/upload_wizard`.
 2. **Step 1** – Click the drop area or drag a single `.safetensors` file onto the page.
 3. Press **Upload** to send the file. A progress bar shows the upload status.
 4. After the model file was uploaded you are asked to upload previews.
@@ -17,8 +17,8 @@ The wizard is the easiest way when you want to upload a new LoRA along with its 
 
 Two separate pages are available for small manual uploads:
 
-- `http://{serverip}:5000/upload` – Select one or multiple `.safetensors` files and submit the form. If a file with the same name already exists the upload is rejected with an error.
-- `http://{serverip}:5000/upload_previews` – Upload preview images for an existing LoRA or a ZIP archive containing previews. If you pass a `lora` query parameter the form will automatically target that LoRA.
+- `http://{serverip}:9090/upload` – Select one or multiple `.safetensors` files and submit the form. If a file with the same name already exists the upload is rejected with an error.
+- `http://{serverip}:9090/upload_previews` – Upload preview images for an existing LoRA or a ZIP archive containing previews. If you pass a `lora` query parameter the form will automatically target that LoRA.
 
 After sending the previews you can go to `/detail/<filename>` to review the images and metadata.
 
@@ -29,12 +29,12 @@ The same endpoints can be used with tools like `curl`.
 ```bash
 # Upload a LoRA file
 curl -X POST -F "files=@awesome_lora.safetensors" \
-  http://{serverip}:5000/upload
+  http://{serverip}:9090/upload
 
 # Upload previews for that LoRA
 curl -X POST -F "files=@preview1.png" -F "files=@preview2.png" \
   -F "lora=awesome_lora" \
-  http://{serverip}:5000/upload_previews
+  http://{serverip}:9090/upload_previews
 ```
 
 ## 4. After uploading

--- a/main.py
+++ b/main.py
@@ -197,4 +197,4 @@ async def logout(request: Request):
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=5000)
+    uvicorn.run(app, host="0.0.0.0", port=9090)


### PR DESCRIPTION
## Summary
- default to port 9090 when running the FastAPI server
- update client defaults and documentation to reference port 9090

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891360c604c8333a9501658b45af247