### PR TITLE
fix: update usersetup for mylora package

### DIFF
--- a/mylora/__init__.py
+++ b/mylora/__init__.py
@@ -1,0 +1,21 @@
+"""Compatibility package for MyLora.
+
+This package re-exports modules from the legacy ``loradb`` package to
+provide backward compatibility while the project transitions to the new
+name.
+"""
+
+from importlib import import_module
+import sys
+
+# Re-export top-level modules so ``mylora`` mirrors ``loradb``
+_loradb = import_module("loradb")
+
+# Expose selected submodules (extend as needed)
+sys.modules[__name__ + ".auth"] = import_module("loradb.auth")
+sys.modules[__name__ + ".api"] = import_module("loradb.api")
+sys.modules[__name__ + ".agents"] = import_module("loradb.agents")
+
+# Optionally expose attributes from loradb at package level
+for attr in getattr(_loradb, "__all__", []):
+    globals()[attr] = getattr(_loradb, attr)

--- a/mylora/auth.py
+++ b/mylora/auth.py
@@ -1,0 +1,3 @@
+"""MyLora authentication module wrapper."""
+
+from loradb.auth import *  # noqa: F401,F403

--- a/usersetup.py
+++ b/usersetup.py
@@ -3,7 +3,7 @@
 
 import argparse
 
-from loradb.auth import AuthManager
+from mylora.auth import AuthManager
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- switch usersetup to import AuthManager from new `mylora` package
- add compatibility `mylora` package aliasing legacy `loradb`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68913c35fc508333a2816d3a24b18a32