### PR TITLE
refactor: store database in user directory

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,5 +15,8 @@ STATIC_DIR = BASE_DIR / "loradb" / "static"
 # Directory containing Jinja2 templates
 TEMPLATE_DIR = BASE_DIR / "loradb" / "templates"
 
+# Location of the SQLite database for users and search index
+DB_PATH = Path.home() / ".modelhome" / "index.db"
+
 # Secret key for session cookies
 SECRET_KEY = "change_this_secret"

--- a/loradb/agents/indexing_agent.py
+++ b/loradb/agents/indexing_agent.py
@@ -18,7 +18,7 @@ class IndexingAgent:
     NO_CATEGORY_NAME = "No Category"
 
     def __init__(self, db_path: Path | None = None) -> None:
-        self.db_path = Path(db_path or "loradb/search_index/index.db")
+        self.db_path = Path(db_path or config.DB_PATH)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         recreated = self._ensure_table()

--- a/loradb/auth.py
+++ b/loradb/auth.py
@@ -11,7 +11,7 @@ class AuthManager:
     """Manage user accounts stored in the main SQLite database."""
 
     def __init__(self, db_path: Path | None = None) -> None:
-        self.db_path = Path(db_path or "loradb/search_index/index.db")
+        self.db_path = Path(db_path or config.DB_PATH)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.conn = sqlite3.connect(self.db_path)
         self._ensure_table()


### PR DESCRIPTION
## Summary
- store SQLite database under `~/.modelhome/index.db`
- use central DB path for AuthManager and IndexingAgent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68913ebd3a048333b9c4e792d52a0b2b